### PR TITLE
Adding services for scanner application name and type code

### DIFF
--- a/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
+++ b/include/sick_safetyscanners2/SickSafetyscannersLifeCycle.hpp
@@ -42,6 +42,8 @@
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
 #include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
+#include <sick_safetyscanners2_interfaces/srv/application_name.hpp>
+#include <sick_safetyscanners2_interfaces/srv/type_code.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -66,6 +68,8 @@ class SickSafetyscannersLifeCycle : public rclcpp_lifecycle::LifecycleNode
 
 using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
 using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+using ApplicationName = sick_safetyscanners2_interfaces::srv::ApplicationName;
+using TypeCode = sick_safetyscanners2_interfaces::srv::TypeCode;
 
 public:
   /*!
@@ -100,6 +104,8 @@ private:
   // Services
   rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
   rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ApplicationName>::SharedPtr m_application_name_service;
+  rclcpp::Service<TypeCode>::SharedPtr m_type_code_service;
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
   rcl_interfaces::msg::SetParametersResult
@@ -144,6 +150,16 @@ private:
   bool getConfigMetadata(
     const std::shared_ptr<ConfigMetadata::Request> request,
     std::shared_ptr<ConfigMetadata::Response> response);
+
+  // Callback function to retrieve application name
+  bool getApplicationName(
+    const std::shared_ptr<ApplicationName::Request> request,
+    std::shared_ptr<ApplicationName::Response> response);
+    
+  // Callback function to retrieve type code
+  bool getTypeCode(
+    const std::shared_ptr<TypeCode::Request> request,
+    std::shared_ptr<TypeCode::Response> response);
 
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(

--- a/include/sick_safetyscanners2/SickSafetyscannersRos2.h
+++ b/include/sick_safetyscanners2/SickSafetyscannersRos2.h
@@ -42,6 +42,8 @@
 #include <sick_safetyscanners2_interfaces/msg/extended_laser_scan.hpp>
 #include <sick_safetyscanners2_interfaces/msg/output_paths.hpp>
 #include <sick_safetyscanners2_interfaces/srv/config_metadata.hpp>
+#include <sick_safetyscanners2_interfaces/srv/application_name.hpp>
+#include <sick_safetyscanners2_interfaces/srv/type_code.hpp>
 #include <sick_safetyscanners2_interfaces/srv/field_data.hpp>
 
 #include <sick_safetyscanners2/utils/Conversions.h>
@@ -59,6 +61,8 @@ class SickSafetyscannersRos2 : public rclcpp::Node
 
 using ConfigMetadata = sick_safetyscanners2_interfaces::srv::ConfigMetadata;
 using FieldData = sick_safetyscanners2_interfaces::srv::FieldData;
+using ApplicationName = sick_safetyscanners2_interfaces::srv::ApplicationName;
+using TypeCode = sick_safetyscanners2_interfaces::srv::TypeCode;
 
 public:
   /*!
@@ -79,6 +83,9 @@ private:
   // Services
   rclcpp::Service<ConfigMetadata>::SharedPtr m_config_metadata_service;
   rclcpp::Service<FieldData>::SharedPtr m_field_data_service;
+  rclcpp::Service<ApplicationName>::SharedPtr m_application_name_service;
+  rclcpp::Service<TypeCode>::SharedPtr m_type_code_service;
+
 
   // Parameters
   OnSetParametersCallbackHandle::SharedPtr m_param_callback;
@@ -124,6 +131,16 @@ private:
   bool getConfigMetadata(
     const std::shared_ptr<ConfigMetadata::Request> request,
     std::shared_ptr<ConfigMetadata::Response> response);
+
+  // Callback function to retrieve application name
+  bool getApplicationName(
+    const std::shared_ptr<ApplicationName::Request> request,
+    std::shared_ptr<ApplicationName::Response> response);
+    
+  // Callback function to retrieve type code
+  bool getTypeCode(
+    const std::shared_ptr<TypeCode::Request> request,
+    std::shared_ptr<TypeCode::Response> response);
 
   // Methods Triggering COLA2 calls towards the sensor
   bool getFieldData(

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -87,6 +87,14 @@ SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State&)
               this,
               std::placeholders::_1,
               std::placeholders::_2));
+  m_application_name_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ApplicationName>("application_name",
+    std::bind(&SickSafetyscannersLifeCycle::getApplicationName,
+      this, std::placeholders::_1, std::placeholders::_2));
+  m_type_code_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::TypeCode>("type_code",
+    std::bind(&SickSafetyscannersLifeCycle::getTypeCode,
+      this, std::placeholders::_1, std::placeholders::_2));
 
 
   // Bind callback
@@ -560,6 +568,41 @@ bool SickSafetyscannersLifeCycle::getFieldData(
     response->monitoring_cases.push_back(monitoring_case_msg);
   }
 
+  return true;
+}
+
+bool SickSafetyscannersLifeCycle::getApplicationName(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto app_name = sick::datastructure::ApplicationName();
+  m_device->requestApplicationName(app_name);
+  response->version_c_version = app_name.getVersionCVersion();
+  response->major_version_number = app_name.getVersionMajorVersionNumber();
+  response->minor_version_number = app_name.getVersionMinorVersionNumber();
+  response->release_version_number = app_name.getVersionReleaseNumber();
+  response->name_length = app_name.getNameLength();
+  response->application_name = app_name.getApplicationName();
+  
+  return true;
+}
+
+bool SickSafetyscannersLifeCycle::getTypeCode(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto type_code = sick::datastructure::TypeCode();
+  m_device->requestTypeCode(type_code);
+  response->type_code = type_code.getTypeCode();
+  response->interface_type = type_code.getInterfaceType();
+  response->max_range = type_code.getMaxRange();  
+  
   return true;
 }
 

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -76,6 +76,14 @@ SickSafetyscannersRos2::SickSafetyscannersRos2()
     "field_data",
     std::bind(
       &SickSafetyscannersRos2::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
+  m_application_name_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::ApplicationName>("application_name",
+    std::bind(&SickSafetyscannersRos2::getApplicationName,
+      this, std::placeholders::_1, std::placeholders::_2));
+  m_type_code_service =
+    this->create_service<sick_safetyscanners2_interfaces::srv::TypeCode>("type_code",
+    std::bind(&SickSafetyscannersRos2::getTypeCode,
+      this, std::placeholders::_1, std::placeholders::_2));
 
   // Bind callback
   std::function<void(const sick::datastructure::Data&)> callback =
@@ -497,6 +505,41 @@ bool SickSafetyscannersRos2::getFieldData(
     response->monitoring_cases.push_back(monitoring_case_msg);
   }
 
+  return true;
+}
+
+bool SickSafetyscannersRos2::getApplicationName(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::ApplicationName::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto app_name = sick::datastructure::ApplicationName();
+  m_device->requestApplicationName(app_name);
+  response->version_c_version = app_name.getVersionCVersion();
+  response->major_version_number = app_name.getVersionMajorVersionNumber();
+  response->minor_version_number = app_name.getVersionMinorVersionNumber();
+  response->release_version_number = app_name.getVersionReleaseNumber();
+  response->name_length = app_name.getNameLength();
+  response->application_name = app_name.getApplicationName();
+  
+  return true;
+}
+
+bool SickSafetyscannersRos2::getTypeCode(
+  const std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Request> request,
+  std::shared_ptr<sick_safetyscanners2_interfaces::srv::TypeCode::Response> response)
+{
+  // Suppress warning of unused request variable due to empty request fields
+  (void)request;
+
+  auto type_code = sick::datastructure::TypeCode();
+  m_device->requestTypeCode(type_code);
+  response->type_code = type_code.getTypeCode();
+  response->interface_type = type_code.getInterfaceType();
+  response->max_range = type_code.getMaxRange();  
+  
   return true;
 }
 


### PR DESCRIPTION
This PR adds two new services to fetch the scanner application name from datastructure/ApplicationName and scanner type code from datastructure/TypeCode