### PR TITLE
Fix/avoid double scan msg construction

### DIFF
--- a/include/sick_safetyscanners2/utils/MessageCreator.h
+++ b/include/sick_safetyscanners2/utils/MessageCreator.h
@@ -103,7 +103,9 @@ public:
    * \returns The constructed extended LaserScan Message
    */
   sick_safetyscanners2_interfaces::msg::ExtendedLaserScan
-  createExtendedLaserScanMsg(const sick::datastructure::Data& data, rclcpp::Time now);
+  createExtendedLaserScanMsg(const sick::datastructure::Data& data,
+                             const sensor_msgs::msg::LaserScan &scan_msg,
+                             rclcpp::Time now);
 
 
   /*!

--- a/include/sick_safetyscanners2/utils/MessageCreator.h
+++ b/include/sick_safetyscanners2/utils/MessageCreator.h
@@ -104,8 +104,7 @@ public:
    */
   sick_safetyscanners2_interfaces::msg::ExtendedLaserScan
   createExtendedLaserScanMsg(const sick::datastructure::Data& data,
-                             const sensor_msgs::msg::LaserScan &scan_msg,
-                             rclcpp::Time now);
+                             const sensor_msgs::msg::LaserScan &scan_msg);
 
 
   /*!

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -483,7 +483,7 @@ void SickSafetyscannersLifeCycle::receiveUDPPaket(const sick::datastructure::Dat
     auto output_scan = std::make_unique<sensor_msgs::msg::LaserScan>(
       m_msg_creator->createLaserScanMsg(data, now()));
     auto output_extended_scan = std::make_unique<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>(
-      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan, now()));
+      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan));
 
     m_laser_scan_publisher->publish(std::move(output_scan));      
     m_extended_laser_scan_publisher->publish(std::move(output_extended_scan));

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -482,11 +482,12 @@ void SickSafetyscannersLifeCycle::receiveUDPPaket(const sick::datastructure::Dat
   {
     auto output_scan = std::make_unique<sensor_msgs::msg::LaserScan>(
       m_msg_creator->createLaserScanMsg(data, now()));
-    m_laser_scan_publisher->publish(std::move(output_scan));
-
     auto output_extended_scan = std::make_unique<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>(
-      m_msg_creator->createExtendedLaserScanMsg(data, now()));      
+      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan, now()));
+
+    m_laser_scan_publisher->publish(std::move(output_scan));      
     m_extended_laser_scan_publisher->publish(std::move(output_extended_scan));
+
     if (publish_output_paths_) {
       auto output_paths = std::make_unique<sick_safetyscanners2_interfaces::msg::OutputPaths>(
         m_msg_creator->createOutputPathsMsg(data));

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -421,7 +421,7 @@ void SickSafetyscannersRos2::receiveUDPPaket(const sick::datastructure::Data& da
     auto output_scan = std::make_unique<sensor_msgs::msg::LaserScan>(
       m_msg_creator->createLaserScanMsg(data, now()));
     auto output_extended_scan = std::make_unique<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>(
-      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan, now()));
+      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan));
 
     m_laser_scan_publisher->publish(std::move(output_scan));
     m_extended_laser_scan_publisher->publish(std::move(output_extended_scan));

--- a/src/SickSafetyscannersRos2.cpp
+++ b/src/SickSafetyscannersRos2.cpp
@@ -420,11 +420,12 @@ void SickSafetyscannersRos2::receiveUDPPaket(const sick::datastructure::Data& da
   {
     auto output_scan = std::make_unique<sensor_msgs::msg::LaserScan>(
       m_msg_creator->createLaserScanMsg(data, now()));
-    m_laser_scan_publisher->publish(std::move(output_scan));
-
     auto output_extended_scan = std::make_unique<sick_safetyscanners2_interfaces::msg::ExtendedLaserScan>(
-      m_msg_creator->createExtendedLaserScanMsg(data, now()));      
+      m_msg_creator->createExtendedLaserScanMsg(data, *output_scan, now()));
+
+    m_laser_scan_publisher->publish(std::move(output_scan));
     m_extended_laser_scan_publisher->publish(std::move(output_extended_scan));
+
     if (publish_output_paths_) {
       auto output_paths = std::make_unique<sick_safetyscanners2_interfaces::msg::OutputPaths>(
         m_msg_creator->createOutputPathsMsg(data));

--- a/src/utils/MessageCreator.cpp
+++ b/src/utils/MessageCreator.cpp
@@ -145,11 +145,12 @@ MessageCreator::createOutputPathsMsg(const sick::datastructure::Data& data)
 }
 
 sick_safetyscanners2_interfaces::msg::ExtendedLaserScan
-MessageCreator::createExtendedLaserScanMsg(const sick::datastructure::Data& data, rclcpp::Time now)
+MessageCreator::createExtendedLaserScanMsg(const sick::datastructure::Data& data,
+                                           const sensor_msgs::msg::LaserScan &scan_msg,
+                                           rclcpp::Time now)
 {
-  sensor_msgs::msg::LaserScan scan = createLaserScanMsg(data, now);
   sick_safetyscanners2_interfaces::msg::ExtendedLaserScan msg;
-  msg.laser_scan = scan;
+  msg.laser_scan = scan_msg;
 
   std::vector<sick::datastructure::ScanPoint> scan_points =
     data.getMeasurementDataPtr()->getScanPointsVector();

--- a/src/utils/MessageCreator.cpp
+++ b/src/utils/MessageCreator.cpp
@@ -146,8 +146,7 @@ MessageCreator::createOutputPathsMsg(const sick::datastructure::Data& data)
 
 sick_safetyscanners2_interfaces::msg::ExtendedLaserScan
 MessageCreator::createExtendedLaserScanMsg(const sick::datastructure::Data& data,
-                                           const sensor_msgs::msg::LaserScan &scan_msg,
-                                           rclcpp::Time now)
+                                           const sensor_msgs::msg::LaserScan &scan_msg)
 {
   sick_safetyscanners2_interfaces::msg::ExtendedLaserScan msg;
   msg.laser_scan = scan_msg;


### PR DESCRIPTION
Reuse the `laser_scan` msg created from raw_data when creating the `extended_scan` msg